### PR TITLE
Fixes #6 `!!!` is deprecated in Jade ~1.1.5

### DIFF
--- a/template.sublime-snippet
+++ b/template.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
 	<content><![CDATA[
-!!!
+doctype html
 html
 	head(lang="en")
 		title ${1:title name}


### PR DESCRIPTION
Replaced `!!!` with `doctype html`
